### PR TITLE
Use CryoloModel as input/output, other fixes

### DIFF
--- a/sphire/constants.py
+++ b/sphire/constants.py
@@ -1,9 +1,12 @@
 # **************************************************************************
 # *
-# * Authors:    Peter Horvath
-# *             Pablo Conesa
+# * Authors:    Peter Horvath [1]
+# *             Pablo Conesa  [1]
+# *             J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [2]
 # *
-# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * [1] Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# * [2] SciLifeLab, Stockholm University
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -28,6 +31,7 @@
 # we declare global constants to multiple usage
 import os
 
+
 def getCryoloEnvName(version):
     return "cryolo-%s" % version
 
@@ -43,14 +47,23 @@ CONDA_ACTIVATION_CMD_VAR = 'CONDA_ACTIVATION_CMD'
 
 CRYOLO_GENMOD = 'cryolo_model'
 # Model constants
+
+
+def _modelFn(modelKey):
+    return 'gmodel_phosnet_%s.h5' % modelKey
+
 CRYOLO_GENMOD_20190516 = '20190516'
-CRYOLO_GENMOD_20190516_FN = "gmodel_phosnet_" + CRYOLO_GENMOD_20190516 +".h5"
+CRYOLO_GENMOD_20190516_FN = _modelFn(CRYOLO_GENMOD_20190516)
 
 CRYOLO_GENMOD_201909 = '201909'
-CRYOLO_GENMOD_201909_FN = "gmodel_phosnet_" + CRYOLO_GENMOD_201909 +".h5"
+CRYOLO_GENMOD_201909_FN = _modelFn(CRYOLO_GENMOD_201909)
 
 # Default model (latest usually)
 CRYOLO_GENMOD_DEFAULT = os.path.join(CRYOLO_GENMOD + "-" + CRYOLO_GENMOD_201909, CRYOLO_GENMOD_201909_FN)
 
 # crYOLO supported input formats for micrographs
 CRYOLO_SUPPORTED_FORMATS = [".mrc", ".tif", ".tiff", ".jpg"]
+
+# Input options for the training model
+INPUT_MODEL_GENERAL = 0
+INPUT_MODEL_OTHER = 1

--- a/sphire/objects.py
+++ b/sphire/objects.py
@@ -1,0 +1,45 @@
+# **************************************************************************
+# *
+# * Authors:     J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [1]
+# *
+# * [1] SciLifeLab, Stockholm University
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import pyworkflow.object as pwobj
+from pyworkflow.em.data import EMObject
+
+
+class CryoloModel(EMObject):
+    """ Simple class to store the Cryolo training model path. """
+    def __init__(self, path=None, **kwargs):
+        EMObject.__init__(self, **kwargs)
+        self._path = pwobj.String(path)
+
+    def getPath(self):
+        return self._path.get()
+
+    def setPath(self, path):
+        self._path.set(path)
+
+    def __str__(self):
+        return "CryoloModel(path=%s)" % self.getPath()
+

--- a/sphire/protocols/__init__.py
+++ b/sphire/protocols/__init__.py
@@ -1,2 +1,4 @@
+
 from .protocol_cryolo_training import SphireProtCRYOLOTraining
 from .protocol_cryolo_picking import SphireProtCRYOLOPicking
+from .protocol_cryolo_import import SphireProtCryoloImport

--- a/sphire/protocols/protocol_cryolo_import.py
+++ b/sphire/protocols/protocol_cryolo_import.py
@@ -1,0 +1,72 @@
+# **************************************************************************
+# *
+# * Authors:     J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [1]
+# *
+# * [1] SciLifeLab, Stockholm University
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+import json
+
+import pyworkflow.utils as pwutils
+from pyworkflow.em.protocol import ProtImport
+import pyworkflow.protocol.params as params
+
+from sphire import Plugin
+import sphire.convert as convert
+from sphire.objects import CryoloModel
+
+
+class SphireProtCryoloImport(ProtImport):
+    """ Protocol to import an existing crYOLO training model.
+    The model will be registered as an output of this protocol and
+    it can be used later for further training or for picking.
+    """
+    _label = 'cryolo import'
+
+    # -------------------------- DEFINE param functions -----------------------
+    def _defineParams(self, form):
+        form.addSection(label='Import')
+        form.addParam('modelPath', params.PathParam,
+                      label="Training model path",
+                      help="Provide the path of a previous crYOLO training "
+                           "model. ")
+
+    # --------------------------- INSERT steps functions ------------------------
+    def _insertAllSteps(self):
+        self._insertFunctionStep("importModelStep")
+
+    # --------------------------- STEPS functions ------------------------------
+    def importModelStep(self):
+        """ Create a link to the provided input model path
+        and register the output to be used later for further training
+        or picking.
+        """
+        absPath = os.path.abspath(self.modelPath.get())
+        outputPath = self._getExtraPath(os.path.basename(absPath))
+        self.info("Creating link:\n"
+                  "%s -> %s" % (outputPath, absPath))
+        self.info("NOTE: If you move this project to another computer, the symbolic"
+                  "link to the model will be broken, but you can update the link "
+                  "and get it working again. ")
+
+        self._defineOutputs(outputModel=CryoloModel(outputPath))

--- a/sphire/protocols/protocol_cryolo_import.py
+++ b/sphire/protocols/protocol_cryolo_import.py
@@ -69,4 +69,6 @@ class SphireProtCryoloImport(ProtImport):
                   "link to the model will be broken, but you can update the link "
                   "and get it working again. ")
 
+        pwutils.createAbsLink(absPath, outputPath)
+
         self._defineOutputs(outputModel=CryoloModel(outputPath))

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -1,9 +1,12 @@
 # **************************************************************************
 # *
-# * Authors:     David Maluenda (dmaluenda@cnb.csic.es)
-# *              Peter Horvath (phorvath@cnb.csic.es)
+# * Authors:    David Maluenda (dmaluenda@cnb.csic.es) [1]
+# *             Peter Horvath [1]
+# *             J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [2]
 # *
-# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * [1] Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# * [2] SciLifeLab, Stockholm University
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -34,9 +37,10 @@ import pyworkflow.protocol.params as params
 import pyworkflow.protocol.constants as cons
 from pyworkflow.em.protocol import ProtParticlePickingAuto
 
+from sphire import Plugin
 import sphire.convert as convert
 from sphire.constants import CRYOLO_GENMOD_VAR
-from sphire import Plugin
+from sphire.constants import INPUT_MODEL_GENERAL
 
 
 class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
@@ -53,22 +57,23 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
     def _defineParams(self, form):
         ProtParticlePickingAuto._defineParams(self, form)
 
-        form.addParam('useGenMod', params.BooleanParam,
-                      default=True,
-                      label='Use general model?',
+        form.addParam('inputModelFrom', params.EnumParam,
+                      default=INPUT_MODEL_GENERAL,
+                      choices=['general', 'other'],
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      label='Use previous model: ',
                       help="You might use a general network model that consists "
-                           "of real, simulated, particle free datasets"
-                      " on various grids with contaminations and skip training "
+                           "of real, simulated, particle free datasets on "
+                           "various grids with contamination and skip training "
                            "completely or if you would like to "
-                           "improve the results you can use the model from the "
-                           "previous training step by answering no. The general"
-                           " model can be found.")
-        form.addParam('sphireTraining', params.PointerParam,
+                           "improve the results you can use the model from a "
+                           "previous training step or an imported one.")
+        form.addParam('inputModel', params.PointerParam,
                       allowsNull=True,
-                      condition="not useGenMod",
-                      label="Cryolo training run",
-                      pointerClass='SphireProtCRYOLOTraining',
-                      help='Select the previous cryolo training run.')
+                      condition="inputModelFrom!=%d" % INPUT_MODEL_GENERAL,
+                      label="Input model",
+                      pointerClass='CryoloModel',
+                      help='Select an existing crYOLO trained model.')
         form.addParam('conservPickVar', params.FloatParam, default=0.3,
                       label="Confidence threshold",
                       help='If you want to pick less conservatively or more '
@@ -130,7 +135,10 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
 
     # --------------------------- INSERT steps functions -----------------------
     def _insertInitialSteps(self):
-        self.particlePickingRun = self.sphireTraining.get()
+        useGeneral = self.inputModelFrom == INPUT_MODEL_GENERAL
+        self.summaryVar.set("Picking using %s model: \n%s"
+                            % ('(GENERAL)' if useGeneral else '',
+                               self.getInputModel()))
         return [self._insertFunctionStep("createConfigStep")]
 
     # --------------------------- STEPS functions ------------------------------
@@ -186,7 +194,7 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         Plugin.runCryolo(self, 'cryolo_predict.py', args)
 
         # Move output files to a common location
-        outputCoordsDir = os.path.join(workingDir, 'EMAN')
+        outputCoordsDir = os.path.join(workingDir, 'CBOX')
         if os.path.exists(outputCoordsDir):
             self.runJob('mv', '%s/* %s/'
                         % (outputCoordsDir, self.getOutputDir()))
@@ -202,7 +210,7 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         yFlipHeight = convert.getFlipYHeight(micDoneList[0].getFileName())
 
         for mic in micDoneList:
-            coordsFile = os.path.join(outDir, convert.getMicIdName(mic, '.box'))
+            coordsFile = os.path.join(outDir, convert.getMicIdName(mic, '.cbox'))
             if os.path.exists(coordsFile):
                 convert.readMicrographCoords(mic, outputCoords, coordsFile, boxSize,
                                              yFlipHeight=yFlipHeight)
@@ -213,46 +221,40 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
 
     # --------------------------- INFO functions -------------------------------
     def _summary(self):
-        summary = []
-
-        if self.useGenMod:
-            summary.append("Coordinates were picked by the general model: "
-                           "%s \n" % (Plugin.getVar(CRYOLO_GENMOD_VAR)))
-        else:
-            summary.append("Coordinates were picked by the trained model: "
-                           "%s \n" % (self.sphireTraining.get().getOutputModel()))
-        return summary
+        return [self.summaryVar.get()]
 
     def _validate(self):
         validateMsgs = []
 
-        if self.useGenMod:
-            if Plugin.getVar(CRYOLO_GENMOD_VAR) == '':
+        modelPath = self.getInputModel()
+        if not os.path.exists(modelPath):
+            validateMsgs.append("Input model file '%s' does not exists."
+                                % modelPath)
+            if self.inputModelFrom == INPUT_MODEL_GENERAL:
                 validateMsgs.append(
                     "The general model for cryolo must be download from Sphire "
                     "website and ~/.config/scipion/scipion.conf must contain "
                     "the '%s' parameter pointing to the downloaded file."
                     % CRYOLO_GENMOD_VAR)
-            elif not os.path.isfile(Plugin.getVar(CRYOLO_GENMOD_VAR)):
+            else:
                 validateMsgs.append(
-                    "General model not found at '%s' and needed when you would "
-                    "like to use the general network (i.e.: non-training mode). "
-                    "Please check the path in the ~/.config/scipion/scipion.conf.\n"
-                    "You can download the file from the Sphire website."
-                    % Plugin.getVar(CRYOLO_GENMOD_VAR))
+                    "Input model path seems to be wrong. If you have moved the "
+                    "project of location, restore the link to the place where "
+                    "you have the correct model or use the general model for "
+                    "picking. ")
         return validateMsgs
 
     # -------------------------- UTILS functions ------------------------------
     def getInputModel(self):
-        if self.useGenMod:
-            m = Plugin.getVar(CRYOLO_GENMOD_VAR)
+        if self.inputModelFrom == INPUT_MODEL_GENERAL:
+            m = Plugin.getCryoloGeneralModel()
         else:
-            m = self.particlePickingRun.getOutputModel()
+            m = self.inputModel.get().getPath()
 
         return os.path.abspath(m) if m else ''
 
     def getOutputDir(self):
-        return self._getTmpPath('outputEMAN')
+        return self._getTmpPath('outputCBOX')
 
     def getMicsWorkingDir(self, micList):
         wd = 'micrographs_%s' % micList[0].strId()

--- a/sphire/protocols/protocol_cryolo_training.py
+++ b/sphire/protocols/protocol_cryolo_training.py
@@ -159,7 +159,7 @@ class SphireProtCRYOLOTraining(ProtParticlePicking):
             useGeneral = self.inputModelFrom == INPUT_MODEL_GENERAL
             self.summaryVar.set("Fine-tuning input %s model: \n%s"
                                 % ('(GENERAL)' if useGeneral else '',
-                                   self.getInputModel()) )
+                                   self.getInputModel()))
         else:
             self._insertFunctionStep("warmUpNetworkStep")
             self._insertFunctionStep("cryoloModelingStep")


### PR DESCRIPTION
Main changes:
* Added CryoloModel as a general object to represent training models
* Created protocol to import a CryoloModel (addressing issue #9 )
* Now training generates also a CryoloModel
* Both training and picking use CryoloModel as input, instead of protocol as before
* Output is parsed from CBOX files, to register the score given by cryolo
* Added batchSize to training and use default=4 as in original crYOLO GUI
* Fixed summary message about input model, before it has wrong message pointing to current general model and not the one used by the protocol
