### PR TITLE
Allowing CPU for predict

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.0.2: Allowing CPU integration for crYOLO predict.
 3.0.1:
     - python 3 migration
     - cryolo updated to 1.7.2

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,18 @@ Downloaded crYOLO and JANNI general models can be found, respectively, in the fo
 
 ``<SCIPION_HOME>/software/em/janni_model-[model_version]``
 
+Running only with CPU
+---------------------
+CrYOLO is able to `run in CPU <http://sphire.mpg.de/wiki/doku.php?id=downloads:cryolo_1&redirect=1#run_it_on_the_cpu>`_, however this is only recomended for predicting task, not trainning. For that reason, the CPU implementation is only enabled for the ``crYOLO-Picking protocol``. In this protocol, both implementation are possible and you must select one of them in the GPU section of the from.
+
+The CPU implementation of crYOLO **is not installed by default**. Therefore, to be able to run crYOLO-picking only using CPU, you must install the `cryoloCPU-[version]` packages in the ``Plugin Manager >> scipion-em-sphire`` or run
+
+``scipion3 installb cryoloCPU``
+
+The CPU integration of crYOLO is installed under a conda environment called ``cryoloCPU-[version]`` . If you want to modify this environ name, please set the following variable in the scipion's config file.
+
+``CRYOLO_ENV_ACTIVATION_CPU = conda activate cryoloCPU-envName``
+
 Running plugin tests
 --------------------
 To check that everything is properly installed and configured, you might want

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Running only with CPU
 ---------------------
 CrYOLO is able to `run in CPU <http://sphire.mpg.de/wiki/doku.php?id=downloads:cryolo_1&redirect=1#run_it_on_the_cpu>`_, however this is only recomended for predicting task, not trainning. For that reason, the CPU implementation is only enabled for the ``crYOLO-Picking protocol``. In this protocol, both implementation are possible and you must select one of them in the GPU section of the from.
 
-The CPU implementation of crYOLO **is not installed by default**. Therefore, to be able to run crYOLO-picking only using CPU, you must install the `cryoloCPU-[version]` packages in the ``Plugin Manager >> scipion-em-sphire`` or run
+The CPU implementation of crYOLO **is not installed by default**. Therefore, to be able to run the CPU version of crYOLO-picking, you must install the `cryoloCPU-[version]` package in the ``Plugin Manager >> scipion-em-sphire`` or by running
 
 ``scipion3 installb cryoloCPU``
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='3.0.1',  # Required
+    version='3.0.2',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/sphire/__init__.py
+++ b/sphire/__init__.py
@@ -46,18 +46,18 @@ class Plugin(pwem.Plugin):
     def _defineVariables(cls):
         # CRYOLO do NOT need EmVar because it uses a conda environment.
         cls._defineVar(CRYOLO_ENV_ACTIVATION_CPU, DEFAULT_ACTIVATION_CMD_CPU)
-        cls._defineVar(CRYOLO_ENV_ACTIVATION_GPU, DEFAULT_ACTIVATION_CMD_GPU)
+        cls._defineVar(CRYOLO_ENV_ACTIVATION, DEFAULT_ACTIVATION_CMD)
         cls._defineEmVar(CRYOLO_GENMOD_VAR, CRYOLO_GENMOD_DEFAULT)
         cls._defineEmVar(CRYOLO_GENMOD_NN_VAR, CRYOLO_GENMOD_NN_DEFAULT)
         cls._defineEmVar(JANNI_GENMOD_VAR, JANNI_GENMOD_DEFAULT)  # EmVar is used instead of Var because method getVar
         cls._defineEmVar(CRYOLO_NS_GENMOD_VAR, CRYOLO_NS_GENMOD_DEFAULT)
 
     @classmethod
-    def getCryoloEnvActivation(cls, archFlag='gpu'):
-        if archFlag == 'gpu':
-            activation = cls.getVar(CRYOLO_ENV_ACTIVATION_GPU)
-        else:
+    def getCryoloEnvActivation(cls, useCpu=False):
+        if useCpu:
             activation = cls.getVar(CRYOLO_ENV_ACTIVATION_CPU)
+        else:
+            activation = cls.getVar(CRYOLO_ENV_ACTIVATION)
         scipionHome = pw.Config.SCIPION_HOME + os.path.sep
 
         return activation.replace(scipionHome, "", 1)
@@ -91,10 +91,8 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def defineBinaries(cls, env):
-        cls.addCryoloPackage(env, CRYOLO_DEFAULT_VER_NUM,
-                             default=bool(cls.getCondaActivationCmd()), archFlag='gpu')
-        cls.addCryoloPackage(env, CRYOLO_DEFAULT_VER_NUM,
-                             default=bool(cls.getCondaActivationCmd()), archFlag='cpu')
+        cls.addCryoloPackage(env, CRYOLO_DEFAULT_VER_NUM, default=bool(cls.getCondaActivationCmd()))
+        cls.addCryoloPackage(env, CRYOLO_DEFAULT_VER_NUM, default=False, useCpu=True)
         url = "wget ftp://ftp.gwdg.de/pub/misc/sphire/crYOLO-GENERAL-MODELS/"
 
         env.addPackage(CRYOLO_GENMOD, version=CRYOLO_GENMOD_201910,
@@ -146,9 +144,10 @@ class Plugin(pwem.Plugin):
         return neededProgs
 
     @classmethod
-    def addCryoloPackage(cls, env, version, default=False, archFlag='gpu'):
-        CRYOLO_INSTALLED = 'cryolo_%s_%s_installed' % (version, archFlag)
-        ENV_NAME = getCryoloEnvName(version, archFlag)
+    def addCryoloPackage(cls, env, version, default=False, useCpu=False):
+        archFlag = 'CPU' if useCpu else ''
+        CRYOLO_INSTALLED = 'cryolo%s_%s_installed' % (archFlag, version)
+        ENV_NAME = getCryoloEnvName(version, useCpu)
         # try to get CONDA activation command
         installationCmd = cls.getCondaActivationCmd()
 
@@ -162,7 +161,8 @@ class Plugin(pwem.Plugin):
         installationCmd += 'conda activate %s &&' % ENV_NAME
 
         # Install downloaded code
-        installationCmd += 'pip install cryolo[%s]==%s &&' % (archFlag, version)
+        installationCmd += ('pip install cryolo[%s]==%s &&'
+                            % ('cpu' if useCpu else 'gpu', version))
 
         # Flag installation finished
         installationCmd += 'touch %s' % CRYOLO_INSTALLED
@@ -171,7 +171,7 @@ class Plugin(pwem.Plugin):
 
         envPath = os.environ.get('PATH', "")  # keep path since conda likely in there
         installEnvVars = {'PATH': envPath} if envPath else None
-        env.addPackage('cryolo-'+archFlag, version=version,
+        env.addPackage('cryolo'+archFlag, version=version,
                        tar='void.tgz',
                        commands=cryolo_commands,
                        neededProgs=cls.getDependencies(),
@@ -179,9 +179,9 @@ class Plugin(pwem.Plugin):
                        vars=installEnvVars)
 
     @classmethod
-    def runCryolo(cls, protocol, program, args, cwd=None, archFlag='gpu'):
+    def runCryolo(cls, protocol, program, args, cwd=None, useCpu=False):
         """ Run crYOLO command from a given protocol. """
         fullProgram = '%s %s && %s' % (cls.getCondaActivationCmd(),
-                                       cls.getCryoloEnvActivation(archFlag), program)
+                                       cls.getCryoloEnvActivation(useCpu), program)
         protocol.runJob(fullProgram, args, env=cls.getEnviron(), cwd=cwd,
                         numberOfMpi=1)

--- a/sphire/constants.py
+++ b/sphire/constants.py
@@ -35,8 +35,8 @@ import os
 
 # crYOLO ###############################################################################################################
 
-def getCryoloEnvName(version):
-    return "cryolo-%s" % version
+def getCryoloEnvName(version, archFlag='gpu'):
+    return "cryolo[%s]-%s" % (archFlag, version)
 
 V1_5_4 = "1.5.4"
 V1_6_1 = "1.6.1"
@@ -45,9 +45,14 @@ V1_7_2 = "1.7.2"
 VERSIONS = [V1_5_4, V1_6_1, V1_7_2]
 CRYOLO_DEFAULT_VER_NUM = V1_7_2
 
-DEFAULT_ENV_NAME = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM)
-DEFAULT_ACTIVATION_CMD = 'conda activate ' + DEFAULT_ENV_NAME
-CRYOLO_ENV_ACTIVATION = 'CRYOLO_ENV_ACTIVATION'
+DEFAULT_ENV_NAME_GPU = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM, archFlag='gpu')
+DEFAULT_ACTIVATION_CMD_GPU = 'conda activate ' + DEFAULT_ENV_NAME_GPU
+CRYOLO_ENV_ACTIVATION_GPU = 'CRYOLO_ENV_ACTIVATION_GPU'
+
+DEFAULT_ENV_NAME_CPU = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM, archFlag='cpu')
+DEFAULT_ACTIVATION_CMD_CPU = 'conda activate ' + DEFAULT_ENV_NAME_CPU
+CRYOLO_ENV_ACTIVATION_CPU = 'CRYOLO_ENV_ACTIVATION_CPU'
+
 CRYOLO_CUDA_LIB = 'CRYOLO_CUDA_LIB'
 
 

--- a/sphire/constants.py
+++ b/sphire/constants.py
@@ -35,8 +35,8 @@ import os
 
 # crYOLO ###############################################################################################################
 
-def getCryoloEnvName(version, archFlag='gpu'):
-    return "cryolo[%s]-%s" % (archFlag, version)
+def getCryoloEnvName(version, useCpu=False):
+    return "cryolo%s-%s" % ('CPU' if useCpu else '', version)
 
 V1_5_4 = "1.5.4"
 V1_6_1 = "1.6.1"
@@ -45,11 +45,11 @@ V1_7_2 = "1.7.2"
 VERSIONS = [V1_5_4, V1_6_1, V1_7_2]
 CRYOLO_DEFAULT_VER_NUM = V1_7_2
 
-DEFAULT_ENV_NAME_GPU = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM, archFlag='gpu')
-DEFAULT_ACTIVATION_CMD_GPU = 'conda activate ' + DEFAULT_ENV_NAME_GPU
-CRYOLO_ENV_ACTIVATION_GPU = 'CRYOLO_ENV_ACTIVATION_GPU'
+DEFAULT_ENV_NAME = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM)
+DEFAULT_ACTIVATION_CMD = 'conda activate ' + DEFAULT_ENV_NAME
+CRYOLO_ENV_ACTIVATION = 'CRYOLO_ENV_ACTIVATION'
 
-DEFAULT_ENV_NAME_CPU = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM, archFlag='cpu')
+DEFAULT_ENV_NAME_CPU = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM, useCpu=True)
 DEFAULT_ACTIVATION_CMD_CPU = 'conda activate ' + DEFAULT_ENV_NAME_CPU
 CRYOLO_ENV_ACTIVATION_CPU = 'CRYOLO_ENV_ACTIVATION_CPU'
 

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -122,6 +122,10 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
                       help="Maximum number of particles in the image. Only for "
                            "the memory handling. Keep the default value of "
                            "600 or 1000.")
+        form.addHidden(params.USE_GPU, params.BooleanParam, default=True,
+                       expertLevel=params.LEVEL_ADVANCED,
+                       label="Use GPU (vs CPU)",
+                       help="Set to true if you want to use GPU implementation ")
         form.addHidden(params.GPU_LIST, params.StringParam, default='0',
                        expertLevel=cons.LEVEL_ADVANCED,
                        label="Choose GPU IDs",
@@ -196,7 +200,8 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         if self.lowPassFilter:
             args += ' --otf'
 
-        Plugin.runCryolo(self, 'cryolo_predict.py', args)
+        gpuFlag = 'gpu' if self.useGpu.get() else 'cpu'
+        Plugin.runCryolo(self, 'cryolo_predict.py', args, archFlag=gpuFlag)
 
         # Move output files to a common location
         dirs2Move = [os.path.join(workingDir, dir) for dir in ['CBOX', 'DISTR']]

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -250,8 +250,8 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
     def _validate(self):
         validateMsgs = []
 
-        if not self.useGpu.get() and not any(['cryoloCPU' in x for x in
-                                              os.listdir(pwem.Config().EM_ROOT)]):
+        if (not self.useGpu.get() and os.system(Plugin.getCondaActivationCmd() +
+                                                Plugin.getVar(CRYOLO_ENV_ACTIVATION_CPU))):
             validateMsgs.append("CPU implementation of crYOLO is not installed, "
                                 "install 'cryoloCPU' or use the GPU implementation.")
 


### PR DESCRIPTION
Using the CPU integration to predict (pick particles) is possible and viable (see benchmarks below) especially in streaming where the management of the GPU is crucial.

The drawback is: two conda environs are needed, double space and double installation time... maybe it can be not by default.

GPU: ~3s/mic
CPU: 5-6s/mic

I used batches of 4 and 10 for the benchmarks.