### PR TITLE
Fix bug when there are no coordinates

### DIFF
--- a/sphire/__init__.py
+++ b/sphire/__init__.py
@@ -34,7 +34,7 @@ import pyworkflow.utils as pwutils
 import pyworkflow as pw
 from sphire.constants import *
 
-__version__ = '3.0.6'
+__version__ = '3.0.7'
 _logo = "sphire_logo.png"
 _references = ['Wagner2019']
 _sphirePluginDir = os.path.dirname(os.path.abspath(__file__))

--- a/sphire/convert.py
+++ b/sphire/convert.py
@@ -89,10 +89,13 @@ class CoordBoxReader:
         self._file = open(filename, 'r')
 
     def _getDataLength(self):
-        head = next(self._file)  # Read the first line
-        cols = re.split(r'\t+', head.rstrip('\t'))  # Strip it by tab
-        self._file.seek(0)  # Return to the top of the file
-        return len(cols)
+        try:
+            head = next(self._file)  # Read the first line
+            cols = re.split(r'\t+', head.rstrip('\t'))  # Strip it by tab
+            self._file.seek(0)  # Return to the top of the file
+            return len(cols)
+        except StopIteration:
+            return None
 
     def iterCoords(self):
         reader = csv.reader(self._file, delimiter='\t')


### PR DESCRIPTION
Fixed function _getDataLength when there are no coordinates for a given micrograph.