### PR TITLE
Fix command line when using CPU and empty mic lists

### DIFF
--- a/sphire/__init__.py
+++ b/sphire/__init__.py
@@ -34,7 +34,7 @@ import pyworkflow.utils as pwutils
 import pyworkflow as pw
 from sphire.constants import *
 
-__version__ = '3.0.7'
+__version__ = '3.0.8'
 _logo = "sphire_logo.png"
 _references = ['Wagner2019']
 _sphirePluginDir = os.path.dirname(os.path.abspath(__file__))

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -197,12 +197,13 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         args += " -i %s/" % workingDir
         args += " -o %s/" % workingDir
         args += " -t %0.3f" % self.conservPickVar
-        args += " -g %(GPU)s"  # Add GPU that will be set by the executor
+        if self.usingCpu():
+            args += " -g %(GPU)s"  # Add GPU that will be set by the executor
         args += " -nc %d" % self.numCpus.get()
         if self.lowPassFilter:
             args += ' --otf'
 
-        Plugin.runCryolo(self, 'cryolo_predict.py', args, useCpu=not self.useGpu.get())
+        Plugin.runCryolo(self, 'cryolo_predict.py', args, useCpu=self.usingCpu())
 
         # Move output files to a common location
         dirs2Move = [os.path.join(workingDir, dir) for dir in ['CBOX', 'DISTR']]
@@ -251,15 +252,16 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
     def _validate(self):
         validateMsgs = []
 
-        if (not self.useGpu.get() and os.system(Plugin.getCondaActivationCmd() +
-                                                Plugin.getVar(CRYOLO_ENV_ACTIVATION_CPU))):
-            validateMsgs.append("CPU implementation of crYOLO is not installed, "
-                                "install 'cryoloCPU' or use the GPU implementation.")
+        if self.usingCpu():
+            if os.system(Plugin.getCondaActivationCmd() + Plugin.getVar(CRYOLO_ENV_ACTIVATION_CPU)):
+                validateMsgs.append("CPU implementation of crYOLO is not installed, "
+                                    "install 'cryoloCPU' or use the GPU implementation.")
 
-        nprocs = max(self.numberOfMpi.get(), self.numberOfThreads.get())
-        if nprocs < len(self.getGpuList()):
-            validateMsgs.append("Multiple GPUs can not be used by a single process. "
-                                "Make sure you specify more threads than GPUs.")
+        else:
+            nprocs = max(self.numberOfMpi.get(), self.numberOfThreads.get())
+            if nprocs < len(self.getGpuList()):
+                validateMsgs.append("Multiple GPUs can not be used by a single process. "
+                                    "Make sure you specify more threads than GPUs.")
 
         modelPath = self.getInputModel()
         if not os.path.exists(modelPath):
@@ -321,6 +323,9 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         if len(micList) > 1:
             wd += '-%s' % micList[-1].strId()
         return wd
+
+    def usingCpu(self):
+        return not self.useGpu.get()
 
     def _getEstimatedBoxSize(self):
         sizeSummaryFilePattern = os.path.join(self.getOutputDISTRDir(),

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -197,7 +197,7 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         args += " -i %s/" % workingDir
         args += " -o %s/" % workingDir
         args += " -t %0.3f" % self.conservPickVar
-        if self.usingCpu():
+        if not self.usingCpu():
             args += " -g %(GPU)s"  # Add GPU that will be set by the executor
         args += " -nc %d" % self.numCpus.get()
         if self.lowPassFilter:

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -183,6 +183,9 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
         self._pickMicrographList([micrograph], args)
 
     def _pickMicrographList(self, micList, *args):
+        if not micList:  # maybe in continue cases, need to properly check
+            return
+
         def cleanAndMakePath(inDirectory):
             pwutils.cleanPath(inDirectory)
             pwutils.makePath(inDirectory)


### PR DESCRIPTION
### This PR fix two bugs:
* When using cryolo in CPU, there was still passing %(GPU) template to the command line
* When stoping the job and continue, it seems that there are some empty micList that caused the whole protocol to fail