### PR TITLE
Multiply estimated box size by a factor (parameter)

### DIFF
--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -137,6 +137,13 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
                             " crYOLO can use multiple GPUs - in that case"
                             " set to i.e. *0 1 2*.")
 
+        form.addParam('boxSizeFactor', params.FloatParam,
+                      default=1.5,
+                      expertLevel=cons.LEVEL_ADVANCED,
+                      label="Adjust estimated box size by",
+                      help="Value to multiply crYOLO estimated box size to be registered in the "
+                            "SetOfCoordinates. It is usually very tight to make a later extraction")
+
         form.addParallelSection(threads=1, mpi=1)
 
         self._defineStreamingParams(form)
@@ -223,6 +230,8 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
             else:  # If not crYOLO estimates it
                 self.boxSizeEstimated.set(True)
                 boxSize = self._getEstimatedBoxSize()
+                boxSize = int(boxSize * self.boxSizeFactor.get())
+
             outputCoords.setBoxSize(boxSize)
 
         # Calculate if flip is needed

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -138,7 +138,7 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
                             " set to i.e. *0 1 2*.")
 
         form.addParam('boxSizeFactor', params.FloatParam,
-                      default=1.5,
+                      default=1,
                       expertLevel=cons.LEVEL_ADVANCED,
                       label="Adjust estimated box size by",
                       help="Value to multiply crYOLO estimated box size to be registered in the "

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -230,7 +230,9 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
             else:  # If not crYOLO estimates it
                 self.boxSizeEstimated.set(True)
                 boxSize = self._getEstimatedBoxSize()
-                boxSize = int(boxSize * self.boxSizeFactor.get())
+
+                if self.boxSizeFactor.get() != 1:
+                    boxSize = int(boxSize * self.boxSizeFactor.get())
 
             outputCoords.setBoxSize(boxSize)
 

--- a/sphire/protocols/protocol_cryolo_picking.py
+++ b/sphire/protocols/protocol_cryolo_picking.py
@@ -248,12 +248,16 @@ class SphireProtCRYOLOPicking(ProtParticlePickingAuto):
                                              yFlipHeight=yFlipHeight,
                                              boxSizeEstimated=self.boxSizeEstimated)
 
-    def createOutputStep(self):
+        # Register box size
+        self.createBoxSizeOutput(outputCoords)
+
+    def createBoxSizeOutput(self, coordSet):
         """ The output is just an Integer. Other protocols can use it in those
             IntParam if it has set allowsPointer=True
         """
-        boxSize = Integer(self.outputCoordinates.getBoxSize())
-        self._defineOutputs(boxsize=boxSize)
+        if not hasattr(self, "boxsize"):
+            boxSize = Integer(coordSet.getBoxSize())
+            self._defineOutputs(boxsize=boxSize)
 
     # --------------------------- INFO functions ------------------------------
     def _summary(self):

--- a/sphire/tests/test_protocol_cryolo.py
+++ b/sphire/tests/test_protocol_cryolo.py
@@ -279,24 +279,27 @@ class TestCryolo(BaseTest):
 
     def testPickingNoBoxSize(self):
         # No training mode picking, box size not provided by user
-        self._runPickingTest(boxSize=0, label='Picking - Box size estimated')
+        prot = self._runPickingTest(boxSize=0, label='Picking - Box size estimated', boxSizeFactor=1.5)
+        self.assertEqual(prot.outputCoordinates.getBoxSize(), 72, "Estimated box size does not match.")
 
     def testPickingBoxSize(self):
         # No training mode picking, box size provided by user
         self._runPickingTest(boxSize=50, label='Picking - Box size provided')
 
-    def _runPickingTest(self, boxSize, label):
+    def _runPickingTest(self, boxSize, label, boxSizeFactor=1):
         protcryolo = self.newProtocol(
             protocols.SphireProtCRYOLOPicking,
             inputMicrographs=self.protPreprocess.outputMicrographs,
             boxSize=boxSize,
             input_size=750,
+            boxSizeFactor=boxSizeFactor,
             streamingBatchSize=10)
 
         protcryolo.setObjLabel(label)
         self.launchProtocol(protcryolo)
         self.assertSetSize(protcryolo.outputCoordinates,
                            msg="There was a problem picking with crYOLO")
+        return protcryolo
 
     def testPickingValidationGeneral(self):
         # No training mode picking


### PR DESCRIPTION
This, by default, multiplies the estimated box size from cryolo by 1.5. It's an advanced parameter so the user can change the factor. This will help getting more accurate box sizes in template workflows

