### PR TITLE
Fixing error related to numpy

### DIFF
--- a/sphire/__init__.py
+++ b/sphire/__init__.py
@@ -156,7 +156,7 @@ class Plugin(pwem.Plugin):
         # Creating the environment
         if version in [V1_8_2]:
             installationCmd += 'conda create -y -n %s -c conda-forge -c anaconda ' \
-                               'python=%s pyqt=5 cudatoolkit=10.0.130 cudnn=7.6.5 numpy=1.18.5 ' \
+                               'python=%s pyqt=5 cudatoolkit=10.0.130 cudnn=7.6.5 numpy=1.20 ' \
                                'libtiff wxPython=4.1.1  adwaita-icon-theme pip=20.2.3 &&' \
                                % (ENV_NAME, pythonVersion)
             boxManagerversion = '1.4'

--- a/sphire/__init__.py
+++ b/sphire/__init__.py
@@ -34,7 +34,7 @@ import pyworkflow.utils as pwutils
 import pyworkflow as pw
 from sphire.constants import *
 
-__version__ = '3.0.9'
+__version__ = '3.0.10'
 _logo = "sphire_logo.png"
 _references = ['Wagner2019']
 _sphirePluginDir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This has been reported today:

scipionuser@scipion-master:~/ScipionUserData/projects$ more 2022_02_21_dunia-asensio_000081/Runs/003508_SphireProtCRYOLOPicking/logs/run.stderr
Traceback (most recent call last):
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/bin/cryolo_predict.py", line 5, in <module>
    from cryolo.predict import _main_
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/cryolo/predict.py", line 31, in <module>
    from cryolo.utils import BoundBox
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/cryolo/utils.py", line 25, in <module>
    from . import imagereader
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/cryolo/imagereader.py", line 13, in <module>
    import imageio
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/__init__.py", line 22, in <module>
    from .core import FormatManager, RETURN_BYTES
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/core/__init__.py", line 16, in <module>
    from .format import Format, FormatManager
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/core/format.py", line 40, in <module>
    from ..config import known_plugins, known_extensions, PluginConfig, FileExtension
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/config/__init__.py", line 7, in <module>
    from .plugins import known_plugins, PluginConfig
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/config/plugins.py", line 4, in <module>
    from ..core.legacy_plugin_wrapper import LegacyPlugin
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/core/legacy_plugin_wrapper.py", line 6, in <module>
    from .v3_plugin_api import PluginV3, ImageProperties
  File "/home/scipionuser/miniconda3/envs/cryolo-1.8.2/lib/python3.7/site-packages/imageio/core/v3_plugin_api.py", line 2, in <module>
    from numpy.typing import ArrayLike
ModuleNotFoundError: No module named 'numpy.typing'
Traceback (most recent call last):
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/protocol/protocol.py", line 201, in run
    self._run()
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/protocol/protocol.py", line 252, in _run
    resultFiles = self._runFunc()
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/protocol/protocol.py", line 248, in _runFunc
    return self._func(*self._args)
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pwem/protocols/protocol_particles_picking.py", line 286, in pickMicrographListStep
    self._pickMicrographList(micList, *args)
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/sphire/protocols/protocol_cryolo_picking.py", line 216, in _pickMicrographList
    Plugin.runCryolo(self, 'cryolo_predict.py', args, useCpu=self.usingCpu())
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/sphire/__init__.py", line 195, in runCryolo
    protocol.runJob(fullProgram, args, env=cls.getEnviron(), cwd=cwd,
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/protocol/protocol.py", line 1441, in runJob
    self._stepsExecutor.runJob(self._log, program, arguments, **kwargs)
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/protocol/executor.py", line 65, in runJob
    process.runJob(log, programName, params,
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/utils/process.py", line 52, in runJob
    return runCommand(command, env, cwd)
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/site-packages/pyworkflow/utils/process.py", line 67, in runCommand
    check_call(command, shell=True, stdout=sys.stdout, stderr=sys.stderr,
  File "/home/scipionuser/miniconda3/envs/scipion3/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command ' eval "$(/home/scipionuser/miniconda3/bin/conda shell.bash hook)"&& conda activate cryolo-1.8.2 && cryolo_predict.py -c Runs/003508_SphireProtCRYOLOPicking/extra/config.json -w /home/sci
pionuser/scipion3/software/em/cryolo_model-202005_N63_c17/gmodel_phosnet_202005_N63_c17.h5 -i Runs/003508_SphireProtCRYOLOPicking/tmp/micrographs_1-16/ -o Runs/003508_SphireProtCRYOLOPicking/tmp/micrographs_1-16/ -t 0.300 -g 0
 -nc 4 --otf' returned non-zero exit status 1.
Protocol failed: Command ' eval "$(/home/scipionuser/miniconda3/bin/conda shell.bash hook)"&& conda activate cryolo-1.8.2 && cryolo_predict.py -c Runs/003508_SphireProtCRYOLOPicking/extra/config.json -w /home/scipionuser/s
cipion3/software/em/cryolo_model-202005_N63_c17/gmodel_phosnet_202005_N63_c17.h5 -i Runs/003508_SphireProtCRYOLOPicking/tmp/micrographs_1-16/ -o Runs/003508_SphireProtCRYOLOPicking/tmp/micrographs_1-16/ -t 0.300 -g 0 -nc 4 --o
tf' returned non-zero exit status 1.

 'numpy.typing' was introduced in 1.20

Maybe imageio has to be fixed. I don't know.