### PR TITLE
refactor napari viewer to run in the project's Tmp

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+3.1.11:
+    - add cryolo 1.9.6 and napari-boxmanager 0.4.4
+    - convert tomograms to mrc for napari_boxmanager viewer
+    - napari viewer runs in the project Tmp folder
 3.1.10: Fix: plugin works in the absence of tomo plugin
 3.1.9: ftp links are not working, replaced by https
 3.1.8: Fix: coordinates 3d sent to napari are not flipped on Y axis.

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,11 @@ depending on your conda version and shell you will need something different:
 
 CONDA_ACTIVATION_CMD = eval "$(/extra/miniconda3/bin/conda shell.bash hook)"
 
-**CRYOLO_ENV_ACTIVATION** (default = conda activate cryolo-1.9.3):
+**CRYOLO_ENV_ACTIVATION** (default = conda activate cryolo-1.9.6):
 Command to activate the crYOLO environment.
+
+**NAPARI_ENV_ACTIVATION** (default = conda activate napari-0.4.4):
+Command to activate napari environment (used only for tomo picker viewer).
 
 Downloaded crYOLO and JANNI general models can be found in the following locations:
 
@@ -101,7 +104,7 @@ The CPU version of crYOLO is installed under a separate conda environment called
 Supported versions
 ------------------
 
-1.8.2, 1.8.4, 1.8.5, 1.9.3
+1.8.4, 1.8.5, 1.9.3, 1.9.6
 
 Protocols
 ---------

--- a/sphire/constants.py
+++ b/sphire/constants.py
@@ -40,12 +40,12 @@ def getNaparyEnvName(version):
     return f"napari-{version}"
 
 
-V1_8_2 = "1.8.2"
 V1_8_4 = "1.8.4"
 V1_8_5 = "1.8.5"
 V1_9_3 = "1.9.3"
+V1_9_6 = "1.9.6"
 
-VERSIONS = [V1_8_2, V1_8_4, V1_8_5, V1_9_3]
+VERSIONS = [V1_8_4, V1_8_5, V1_9_3, V1_9_6]
 CRYOLO_DEFAULT_VER_NUM = VERSIONS[-1]
 
 DEFAULT_ENV_NAME = getCryoloEnvName(CRYOLO_DEFAULT_VER_NUM)
@@ -105,13 +105,14 @@ JANNI_GENMOD_DEFAULT = os.path.join(f"{JANNI_GENMOD}-{JANNI_GENMOD_20190703}",
 
 # Napari variables
 V0_3_11 = '0.3.11'
+V0_4_4 = '0.4.4'
 
-defaultVersion = V0_3_11
+NAPARI_DEF_VER = V0_4_4
 
-NAPARI_ACTIVATION_CMD = 'conda activate %s' % getNaparyEnvName(defaultVersion)
+NAPARI_ACTIVATION_CMD = 'conda activate %s' % getNaparyEnvName(NAPARI_DEF_VER)
+NAPARI_ENV_ACTIVATION = 'NAPARI_ENV_ACTIVATION'
 NAPARI_BOXMANAGER = 'napari_boxmanager'
 CBOX_FILAMENTS_FOLDER = 'CBOX_FILAMENTS_TRACED'
-NAPARI_VIEWER_CBOX_FILES = 'napariViewerCboxFiles'
 
 # Filament parameters
 STRAIGHTNESS_METHOD = ['NONE', 'LINE_STRAIGHTNESS', 'RMSD']

--- a/sphire/protocols/protocol_cryolo_napari_tomo_picking.py
+++ b/sphire/protocols/protocol_cryolo_napari_tomo_picking.py
@@ -61,11 +61,8 @@ class SphireProtCRYOLONapariTomoPicker(ProtTomoPicking):
         This step prepare a folder with a link to the tomograms and create a
         folder where the .cbox files will be generated
         """
-        for tomogram in self.getInputTomos():
-            tomoFn = tomogram.getFileName()
-            source = os.path.abspath(tomoFn)
-            dest = self._getExtraPath(os.path.basename(tomoFn))
-            createAbsLink(source, dest)
+        tomoList = [tomo.clone() for tomo in self.getInputTomos()]
+        convert.convertMicrographs(tomoList, self._getExtraPath())
 
     def runCoordinatePickingStep(self):
         # Getting the first tomogram to check if the .cbox file exist
@@ -78,7 +75,8 @@ class SphireProtCRYOLONapariTomoPicker(ProtTomoPicking):
 
         view = SphireGenericView(None, self, self.getInputTomos(),
                                  isInteractive=True,
-                                 itemDoubleClick=True)
+                                 itemDoubleClick=True,
+                                 tmpDir=self._getExtraPath())
         view.show()
 
         if os.path.exists(filePath):

--- a/sphire/protocols/protocol_cryolo_tomo_picking.py
+++ b/sphire/protocols/protocol_cryolo_tomo_picking.py
@@ -115,8 +115,8 @@ class SphireProtCRYOLOTomoPicking(ProtCryoloBase, ProtTomoPicking):
         form.addParam('angle_delta', params.IntParam, default=10,
                       condition='doFilament',
                       label="Angle delta",
-                      help="Angle delta in degree. This value is good more or"
-                           " less straight filament. More curvy filament might "
+                      help="Angle delta in degree. This value is good more or "
+                           "less straight filament. More curvy filament might "
                            "require values around 20")
 
         form.addParam('directional_method', params.EnumParam, default=1,
@@ -126,8 +126,6 @@ class SphireProtCRYOLOTomoPicking(ProtCryoloBase, ProtTomoPicking):
                       help="Directional method")
 
         form.addParam('filament_width', params.IntParam, default=None,
-                      expertLevel=params.LEVEL_ADVANCED,
-                      allowsNull=True,
                       condition='doFilament and directional_method==0',
                       label="Filament width (px)")
 
@@ -135,7 +133,7 @@ class SphireProtCRYOLOTomoPicking(ProtCryoloBase, ProtTomoPicking):
                       expertLevel=params.LEVEL_ADVANCED,
                       condition='doFilament and directional_method==0',
                       label="Mask width",
-                      help="Mask width in pixel. A gaussian filter mask is used"
+                      help="Mask width in pixel. A gaussian filter mask is used "
                            "to estimate the direction of the filaments. This "
                            "parameter defines how elongated the mask is. The "
                            "default value typically don't has to be changed")

--- a/sphire/viewers/viewer_napari.py
+++ b/sphire/viewers/viewer_napari.py
@@ -29,7 +29,6 @@ import pyworkflow.utils as pwutils
 
 import tomo.objects
 import sphire.convert
-from sphire import NAPARI_VIEWER_CBOX_FILES
 
 
 class NapariViewer(pwviewer.Viewer):
@@ -49,25 +48,24 @@ class NapariViewer(pwviewer.Viewer):
 
         if issubclass(cls, tomo.objects.SetOfCoordinates3D):
             from .views_tkinter_tree import SphireGenericView
-            self.generateCboxFiles(obj.getPrecedents(), obj)
+            tmpDir = self.generateCboxFiles(obj.getPrecedents(), obj)
             setCoord3DView = SphireGenericView(self.getTkRoot(), self.protocol,
                                                obj.getPrecedents(),
                                                isInteractive=True,
-                                               itemDoubleClick=True)
+                                               itemDoubleClick=True,
+                                               tmpDir=tmpDir)
             views.append(setCoord3DView)
 
         return views
 
     def generateCboxFiles(self, tomograms, coordinates3D):
-        """ Converts a set of coordinates to box files and binaries to mrc.
-        It generates 2 folders: one for the box files and another for
-        the mrc files.
-        """
-        inputTomos = tomograms
-        coordSet = coordinates3D
+        """ Converts a set of coordinates to cbox files and tomograms to mrc. """
+        tmpDir = self._getTmpPath(coordinates3D.getName())
+        pwutils.cleanPath(tmpDir)
+        pwutils.makePath(tmpDir)
 
-        path = self.protocol._getExtraPath(NAPARI_VIEWER_CBOX_FILES)
-        pwutils.makePath(path)
+        tomoList = [tomo.clone() for tomo in tomograms]
+        sphire.convert.convertMicrographs(tomoList, tmpDir)
+        sphire.convert.writeSetOfCoordinates3D(tmpDir, coordinates3D, tomoList)
 
-        tomoList = [tomo.clone() for tomo in inputTomos]
-        sphire.convert.writeSetOfCoordinates3D(path, coordSet, tomoList)
+        return tmpDir

--- a/sphire/viewers/views_tkinter_tree.py
+++ b/sphire/viewers/views_tkinter_tree.py
@@ -217,7 +217,7 @@ class SphireListDialog(ListDialog):
         ext = getExt(tomogram.getFileName())
 
         if ext in CRYOLO_SUPPORTED_FORMATS:
-            tomogramPath = tomogram.getFileName()
+            tomogramPath = os.path.basename(tomogram.getFileName())
         else:
             tomogramPath = replaceBaseExt(tomogram.getFileName(), "mrc")
 


### PR DESCRIPTION
    - add cryolo 1.9.6 and napari-boxmanager 0.4.4
    - convert tomograms to mrc (or link) for napari_boxmanager viewer
    - napari viewer runs in the project Tmp folder

Installation and all protocols tested. Viewer tested on 3D coords from other plugins, looks working as well.