### PR TITLE
Tolerate failure for streaming spa picking

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.2.3: Tolerate failure for streaming spa picking
 3.2.2: fix emtools dependency
 3.2.1: fix broken tomo training protocol
 3.2:

--- a/sphire/__init__.py
+++ b/sphire/__init__.py
@@ -33,7 +33,7 @@ from pyworkflow.utils import runJob
 from .constants import *
 
 
-__version__ = '3.2.2'
+__version__ = '3.2.3'
 _logo = "sphire_logo.png"
 _references = ['Wagner2019']
 

--- a/sphire/protocols/protocol_base.py
+++ b/sphire/protocols/protocol_base.py
@@ -111,7 +111,8 @@ class ProtCryoloBase(EMProtocol):
                       condition='lowPassFilter',
                       label="Cut-off resolution (A)",
                       help="Specifies the absolute cut-off resolution for the "
-                           "low-pass filter. Recommended value sampling/0.3")
+                           "low-pass filter. The recommended value is sampling/0.3. "
+                           "To automatically calculate the recommended value, input -1.")
         form.addParam('numCpus', params.IntParam, default=4,
                       label="Number of CPUs",
                       help="*Important!* This is different from number of threads "
@@ -159,7 +160,9 @@ class ProtCryoloBase(EMProtocol):
         maxBoxPerImage = self.max_box_per_image.get()
         sampling = inputData.getSamplingRate()
         nyquist = 2 * sampling
-        if nyquist >= self.absCutOffFreq.get():
+        if self.absCutOffFreq.get() == -1:
+            absCutOfffreq = sampling / (sampling / 0.3)  # Recommended by cryolo
+        elif nyquist >= self.absCutOffFreq.get():
             absCutOfffreq = 0.5
         else:
             absCutOfffreq = sampling/self.absCutOffFreq.get()


### PR DESCRIPTION
I experienced stability issues with Cryolo SPA picking. Occasionally, batches of micrographs failed to generate coordinates, causing the protocol to fail. In this fix, we are addressing these issues as follows:

- Tolerate failures in different batches.
- Handle the scenario where if the first batch fails, there will be no box size estimation, and if not tolerated, the protocol will fail.
- Add the option to autotune the cut-off frequency of the low-pass filter (as recommended by developers).