### PR TITLE
 - Users: hide protocol cryolo_tomo_trining until it is reviewed.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+
+3.2.4:
+ - Users: hide protocol cryolo_tomo_trining until it is reviewed.
+ - Developers: add toml file and update the GitHub action to point to the centralized one.
 3.2.3: Tolerate failure for streaming spa picking
 3.2.2: fix emtools dependency
 3.2.1: fix broken tomo training protocol

--- a/sphire/protocols/__init__.py
+++ b/sphire/protocols/__init__.py
@@ -36,5 +36,5 @@ from .protocol_cryolo_picking_tasks import SphireProtCRYOLOPickingTasks
 with weakImport('tomo'):
     from .protocol_cryolo_tomo_picking import SphireProtCRYOLOTomoPicking
     from .protocol_cryolo_napari_tomo_picking import SphireProtCRYOLONapariTomoPicker
-    from .protocol_cryolo_tomo_training import SphireProtCRYOLOTomoTraining
+    # from .protocol_cryolo_tomo_training import SphireProtCRYOLOTomoTraining
 


### PR DESCRIPTION
 - Developers: add toml file and update the GitHub action to point to the centralized one.